### PR TITLE
Upgrade to more recent image of Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:19.03
+FROM docker:20.10
 
 RUN apk add bash
 


### PR DESCRIPTION
Thanks for publishing this package. It's just what we needed!

A recent change in Docker 20.10.3 adds support for the use of `host.internal.docker` on Linux machines (which are what's typically used in Github Actions). It would be valuable for our project - and probably others! - to upgrade to 20.10.x.

Relevant issue: https://github.com/docker/for-linux/issues/264#issuecomment-779490294