### PR TITLE
Only replace entrypoint if shell argument is non-empty

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: false
     default: sh
   precommand_prefix: 
-    description: 'flag needed before \'run\' command'
+    description: 'flag needed before ''run'' command'
     required: false
     default: -c
   registry:

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Use a specific shell'
     required: false
     default: sh
+  precommand_prefix: 
+    description: 'flag needed before \'run\' command'
+    required: false
+    default: -c
   registry:
     description: 'Registry'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,4 +10,8 @@ if [ ! -z $INPUT_DOCKER_NETWORK ];
 then INPUT_OPTIONS="$INPUT_OPTIONS --network $INPUT_DOCKER_NETWORK"
 fi
 
-exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS --entrypoint=$INPUT_SHELL $INPUT_IMAGE -c "`cat semicolon_delimited_script`"
+if [ ! -z $INPUT_SHELL ];
+then INPUT_OPTIONS="$INPUT_OPTIONS --entrypoint=$INPUT_SHELL"
+fi
+
+exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS $INPUT_IMAGE -c "`cat semicolon_delimited_script`"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,4 +14,7 @@ if [ ! -z $INPUT_SHELL ];
 then INPUT_OPTIONS="$INPUT_OPTIONS --entrypoint=$INPUT_SHELL"
 fi
 
-exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS $INPUT_IMAGE -c "`cat semicolon_delimited_script`"
+if [ ! -z $INPUT_SHELL ];
+then INPUT_OPTIONS="$INPUT_OPTIONS --entrypoint=$INPUT_SHELL"
+fi
+exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS $INPUT_IMAGE $INPUT_PRECOMMAND_PREFIX "`cat semicolon_delimited_script`"


### PR DESCRIPTION
This PR enables the use of images with complex default ENTRYPOINT arrays. Since I have not managed to find how to replace the default ENTRYPOINT with a commandline provided _array_ of values this change enables the use of the original ENTRYPOINT if `shell` is empty.

This allows the use of docker images with complex ENTRYPOINT arrays, such as mine with 

```Dockerfile
ENTRYPOINT ["conda", "run", "-n", "Template", "--no-capture-output", "bash", "-c"]
```

EDIT: The `-c` addition in this action's entrypoint is inconsistent with docker images that will be run "manually"...so I added another input variable to enable dropping it for images that do not need it.