### PR TITLE
Remove temporary "semicolon_delimited_script"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,10 +4,8 @@ if [ ! -z $INPUT_USERNAME ];
 then echo $INPUT_PASSWORD | docker login $INPUT_REGISTRY -u $INPUT_USERNAME --password-stdin
 fi
 
-echo "$INPUT_RUN" | sed -e 's/\\n/;/g' > semicolon_delimited_script
-
 if [ ! -z $INPUT_DOCKER_NETWORK ];
 then INPUT_OPTIONS="$INPUT_OPTIONS --network $INPUT_DOCKER_NETWORK"
 fi
 
-exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS --entrypoint=$INPUT_SHELL $INPUT_IMAGE -c "`cat semicolon_delimited_script`"
+exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS --entrypoint=$INPUT_SHELL $INPUT_IMAGE -c "${INPUT_RUN//$'\n'/;}"


### PR DESCRIPTION
When using this action, the directory will be left with a "semicolon_delimited_script" file.

In my case, this script was then built to a container and distributed to the world, just because it wasn't deleted after usage.

When using use bash [Shell Parameter Expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html), we do not need to create this file at all.