### PR TITLE
Add ability to specify volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
     password: ${{ secrets.DOCKER_PASSWORD }}
     registry: gcr.io
     image: private-image:latest
-    options: -v ${{ github.workspace }}:/work -e ABC=123
+    volumes: ${{ github.workspace }}:/work,/other/path:/other/path # comma separated list
+    options: -e ABC=123
     run: |
       echo "Running Script"
       /work/run-script

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   image:
     description: 'Image'
     required: true
+  volumes:
+    description: "Volume mounts"
+    required: false
   options:
     description: 'Options'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,9 @@ then INPUT_OPTIONS="$INPUT_OPTIONS --network $INPUT_DOCKER_NETWORK"
 fi
 
 if [ -n "$INPUT_VOLUMES" ];
+then 
 VOLUMES=$(echo "$INPUT_VOLUMES" | sed -r 's/[ ]?,[ ]?/ -v /g')
-then INPUT_OPTIONS="$INPUT_OPTIONS -v $VOLUMES"
+INPUT_OPTIONS="$INPUT_OPTIONS -v $VOLUMES"
 fi
 
 exec docker run -v /var/run/docker.sock:/var/run/docker.sock "$INPUT_OPTIONS" --entrypoint="$INPUT_SHELL" "$INPUT_IMAGE" -c "${INPUT_RUN//$'\n'/;}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 
-if [ ! -z $INPUT_USERNAME ];
-then echo $INPUT_PASSWORD | docker login $INPUT_REGISTRY -u $INPUT_USERNAME --password-stdin
+if [ -n "$INPUT_USERNAME" ];
+then echo "$INPUT_PASSWORD" | docker login "$INPUT_REGISTRY" -u "$INPUT_USERNAME" --password-stdin
 fi
 
-if [ ! -z $INPUT_DOCKER_NETWORK ];
+if [ -n "$INPUT_DOCKER_NETWORK" ];
 then INPUT_OPTIONS="$INPUT_OPTIONS --network $INPUT_DOCKER_NETWORK"
 fi
 
-exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS --entrypoint=$INPUT_SHELL $INPUT_IMAGE -c "${INPUT_RUN//$'\n'/;}"
+if [ -n "$INPUT_VOLUMES" ];
+VOLUMES=$(echo "$INPUT_VOLUMES" | sed -r 's/[ ]?,[ ]?/ -v /g')
+then INPUT_OPTIONS="$INPUT_OPTIONS -v $VOLUMES"
+fi
+
+exec docker run -v /var/run/docker.sock:/var/run/docker.sock "$INPUT_OPTIONS" --entrypoint="$INPUT_SHELL" "$INPUT_IMAGE" -c "${INPUT_RUN//$'\n'/;}"


### PR DESCRIPTION
Seeing as this action solves the issue of not being able to specify volumes in steps, it'd be user friendly to take in volumes from a separate input.

Changes:
- Allow specifying `with: volumes:` which expects a comma-separated list
- Update entrypoint.sh to pass `shellcheck`