### PR TITLE
Forward ENV to the sub-container

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@
 - name: Checkout 
   uses: actions/checkout@v2 # Required to mount the Github Workspace to a volume 
 - uses: addnab/docker-run-action@v3
+  env:
+    ABC: 123
   with:
     username: ${{ secrets.DOCKER_USERNAME }}
     password: ${{ secrets.DOCKER_PASSWORD }}
     registry: gcr.io
     image: private-image:latest
-    options: -v ${{ github.workspace }}:/work -e ABC=123
+    options: -v ${{ github.workspace }}:/work
     run: |
       echo "Running Script"
       /work/run-script

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-env > docker-run-action.env
-INPUT_OPTIONS="$INPUT_OPTIONS --env-file ./docker-run-action.env"
+env | grep -v '^#' | xargs > docker-run-action.env
 
 if [ ! -z $INPUT_USERNAME ];
 then echo $INPUT_PASSWORD | docker login $INPUT_REGISTRY -u $INPUT_USERNAME --password-stdin
@@ -11,4 +10,4 @@ if [ ! -z $INPUT_DOCKER_NETWORK ];
 then INPUT_OPTIONS="$INPUT_OPTIONS --network $INPUT_DOCKER_NETWORK"
 fi
 
-exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS --entrypoint=$INPUT_SHELL $INPUT_IMAGE -c "${INPUT_RUN//$'\n'/;}"
+exec docker run --env-file docker-run-action.env -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS --entrypoint=$INPUT_SHELL $INPUT_IMAGE -c "${INPUT_RUN//$'\n'/;}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+env > docker-run-action.env
+INPUT_OPTIONS="$INPUT_OPTIONS --env-file ./docker-run-action.env"
+
 if [ ! -z $INPUT_USERNAME ];
 then echo $INPUT_PASSWORD | docker login $INPUT_REGISTRY -u $INPUT_USERNAME --password-stdin
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-env | grep -v '^#' | xargs > docker-run-action.env
+env | egrep -v  "^(#|;| |INPUT_*|PATH|HOME)" | awk '$1 ~ /^\w+=/' | xargs -0 > docker-run-action.env
 
 if [ ! -z $INPUT_USERNAME ];
 then echo $INPUT_PASSWORD | docker login $INPUT_REGISTRY -u $INPUT_USERNAME --password-stdin


### PR DESCRIPTION
If we were to run any container in our Github workflow using the common approach of `uses: docker://registry.com/container:tag` - the said container would have all of the Github and user-defined environment variables.

Since this action spins up a new container within a container, we lose the Github and any user-defined environment variables in the resulting container, which is unexpected behavior.

Changes:
- Pass the current environment onwards to the sub-container that this action runs.