### PR TITLE
Mount the workspace and set as default workdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
     password: ${{ secrets.DOCKER_PASSWORD }}
     registry: gcr.io
     image: private-image:latest
-    options: -v ${{ github.workspace }}:/work -e ABC=123
+    options: -e ABC=123
     run: |
       echo "Running Script"
       /work/run-script

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
   options:
     description: 'Options'
     required: false
+  workidr:
+    description: 'Workdir for the container'
+    required: false
+    default: ${{ github.workspace }}
   run:
     description: 'Run command in container'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   workdir:
     description: 'Workdir for the container'
     required: false
-    default: ${{ github.workspace }}
+    default: /github/workspace/${{ github.event.repository.name }}
   run:
     description: 'Run command in container'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   options:
     description: 'Options'
     required: false
-  workidr:
+  workdir:
     description: 'Workdir for the container'
     required: false
     default: ${{ github.workspace }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,4 +8,4 @@ if [ ! -z $INPUT_DOCKER_NETWORK ];
 then INPUT_OPTIONS="$INPUT_OPTIONS --network $INPUT_DOCKER_NETWORK"
 fi
 
-exec docker run --workdir $INPUT_WORKDIR -v "/var/run/docker.sock:/var/run/docker.sock" -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" $INPUT_OPTIONS --entrypoint=$INPUT_SHELL $INPUT_IMAGE -c "${INPUT_RUN//$'\n'/;}"
+exec docker run --workdir "$INPUT_WORKDIR" -v "/var/run/docker.sock:/var/run/docker.sock" -v "$RUNNER_WORKSPACE:/github/workspace" $INPUT_OPTIONS --entrypoint=$INPUT_SHELL $INPUT_IMAGE -c "${INPUT_RUN//$'\n'/;}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,4 +8,4 @@ if [ ! -z $INPUT_DOCKER_NETWORK ];
 then INPUT_OPTIONS="$INPUT_OPTIONS --network $INPUT_DOCKER_NETWORK"
 fi
 
-exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS --entrypoint=$INPUT_SHELL $INPUT_IMAGE -c "${INPUT_RUN//$'\n'/;}"
+exec docker run --workdir $INPUT_WORKDIR -v "/var/run/docker.sock:/var/run/docker.sock" -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" $INPUT_OPTIONS --entrypoint=$INPUT_SHELL $INPUT_IMAGE -c "${INPUT_RUN//$'\n'/;}"


### PR DESCRIPTION
Similarly to #23 , when running containers directly, they will automatically mount the Github workspace and set it as the `workdir` for the container, so that all of the repository contents could be accessed (assuming a checkout was done).

This seems like a safe default and it'd be intuitive to keep this flow when running containers via the `docker-run-action`.

Changes:
- Automatically mount the $GITHUB_WORKSPACE
- Ability to specify the `workdir` for the container. Defaults to $GITHUB_WORKSPACE

Note, this change depends on #23 , since the container we are running needs to know about the Github environment variables in order to mount the correct volume for the workspace. As the action is now, we are ignoring all Github and user-defined env vars (set via `env:` on the step).