### PR TITLE
Yf optional quote input

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Docker Run Action Tests
 on:
   push:
     branches:
-      - main
+      - '**'
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@
     run: |
       echo "first line"
       echo "second line"
-
+```

--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@
     run: |
       echo "first line"
       echo "second line"
-```
+

--- a/action.yml
+++ b/action.yml
@@ -16,9 +16,13 @@ inputs:
     required: false
     default: sh
   script_prefix: 
-    description: 'a prefix telling the shell to execute the following (single) string as a script'
+    description: 'A prefix telling the shell to execute the following (single) string as a script'
     required: false
     default: -c
+  quote_argument:
+    description: 'Whether to quote the arguments when providing them to the docker as input'
+    required: false
+    default: true
   registry:
     description: 'Registry'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Use a specific shell'
     required: false
     default: sh
+  script_prefix: 
+    description: 'a prefix telling the shell to execute the following (single) string as a script'
+    required: false
+    default: -c
   registry:
     description: 'Registry'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,9 +8,9 @@ if [ ! -z $INPUT_DOCKER_NETWORK ];
 then INPUT_OPTIONS="$INPUT_OPTIONS --network $INPUT_DOCKER_NETWORK"
 fi
 
-if [ $INPUT_QUOTE_ARGUMENT == "true" ];
+if [ $INPUT_QUOTE_ARGUMENT = "true" ];
 then exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS $INPUT_IMAGE $INPUT_SHELL $INPUT_SCRIPT_PREFIX "${INPUT_RUN//$'\n'/;}"
-elif [ $INPUT_QUOTE_ARGUMENT == "false" ]; then exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS $INPUT_IMAGE $INPUT_SHELL $INPUT_SCRIPT_PREFIX ${INPUT_RUN}
+elif [ $INPUT_QUOTE_ARGUMENT = "false" ]; then exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS $INPUT_IMAGE $INPUT_SHELL $INPUT_SCRIPT_PREFIX ${INPUT_RUN}
 else 
 	echo "Sorry, please specify 'true' or 'false' for the variable quote_argument"
 	exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,9 +8,9 @@ if [ ! -z $INPUT_DOCKER_NETWORK ];
 then INPUT_OPTIONS="$INPUT_OPTIONS --network $INPUT_DOCKER_NETWORK"
 fi
 
-if [ $INPUT_QUOTE_ARGUMENT -eq "true" ];
+if [ $INPUT_QUOTE_ARGUMENT == "true" ];
 then exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS $INPUT_IMAGE $INPUT_SHELL $INPUT_SCRIPT_PREFIX "${INPUT_RUN//$'\n'/;}"
-elif [ $INPUT_QUOTE_ARGUMENT -eq "false" ]; then exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS $INPUT_IMAGE $INPUT_SHELL $INPUT_SCRIPT_PREFIX ${INPUT_RUN}
+elif [ $INPUT_QUOTE_ARGUMENT == "false" ]; then exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS $INPUT_IMAGE $INPUT_SHELL $INPUT_SCRIPT_PREFIX ${INPUT_RUN}
 else 
 	echo "Sorry, please specify 'true' or 'false' for the variable quote_argument"
 	exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,4 +8,7 @@ if [ ! -z $INPUT_DOCKER_NETWORK ];
 then INPUT_OPTIONS="$INPUT_OPTIONS --network $INPUT_DOCKER_NETWORK"
 fi
 
-exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS $INPUT_IMAGE $INPUT_SHELL $INPUT_SCRIPT_PREFIX "${INPUT_RUN//$'\n'/;}"
+if [ -z $INPUT_QUOTE_ARGUMENT ];
+then exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS $INPUT_IMAGE $INPUT_SHELL $INPUT_SCRIPT_PREFIX "${INPUT_RUN//$'\n'/;}"
+else exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS $INPUT_IMAGE $INPUT_SHELL $INPUT_SCRIPT_PREFIX ${INPUT_RUN}
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,4 +8,4 @@ if [ ! -z $INPUT_DOCKER_NETWORK ];
 then INPUT_OPTIONS="$INPUT_OPTIONS --network $INPUT_DOCKER_NETWORK"
 fi
 
-exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS --entrypoint=$INPUT_SHELL $INPUT_IMAGE -c "${INPUT_RUN//$'\n'/;}"
+exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS $INPUT_IMAGE $INPUT_SHELL $INPUT_SCRIPT_PREFIX "${INPUT_RUN//$'\n'/;}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,10 @@ if [ ! -z $INPUT_DOCKER_NETWORK ];
 then INPUT_OPTIONS="$INPUT_OPTIONS --network $INPUT_DOCKER_NETWORK"
 fi
 
-if [ -z $INPUT_QUOTE_ARGUMENT ];
+if [ $INPUT_QUOTE_ARGUMENT -eq "true" ];
 then exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS $INPUT_IMAGE $INPUT_SHELL $INPUT_SCRIPT_PREFIX "${INPUT_RUN//$'\n'/;}"
-else exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS $INPUT_IMAGE $INPUT_SHELL $INPUT_SCRIPT_PREFIX ${INPUT_RUN}
+elif [ $INPUT_QUOTE_ARGUMENT -eq "false" ]; then exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS $INPUT_IMAGE $INPUT_SHELL $INPUT_SCRIPT_PREFIX ${INPUT_RUN}
+else 
+	echo "Sorry, please specify 'true' or 'false' for the variable quote_argument"
+	exit 1
 fi


### PR DESCRIPTION
this PR allows the user to control whether the input to the "script" will be wrapped in quotes (default) or not. 

By specifying 'false' one can then run arbitrary docker images that require various inputs (for this one would also need to disable various other contols:

```yaml
 script_prefix: ""
 shell: ""
 quote_argument: false
```