### PR TITLE
Use ECR Public instead Docker Hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10
+FROM public.ecr.aws/docker/library/docker:20.10
 
 RUN apk add bash
 


### PR DESCRIPTION
Hi! simple change to avoid pull rate limits because of docker hub policies.

This allows to use the  pull cache too from AWS ECR service if you like it

https://gallery.ecr.aws/docker/library/docker