### PR TITLE
Avoid argument splitting through various input

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 if [ ! -z $INPUT_USERNAME ];
-then echo $INPUT_PASSWORD | docker login $INPUT_REGISTRY -u $INPUT_USERNAME --password-stdin
+then echo $INPUT_PASSWORD | docker login "$INPUT_REGISTRY" -u "$INPUT_USERNAME" --password-stdin
 fi
 
 if [ ! -z $INPUT_DOCKER_NETWORK ];
 then INPUT_OPTIONS="$INPUT_OPTIONS --network $INPUT_DOCKER_NETWORK"
 fi
 
-exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS --entrypoint=$INPUT_SHELL $INPUT_IMAGE -c "${INPUT_RUN//$'\n'/;}"
+exec docker run -v "/var/run/docker.sock":"/var/run/docker.sock" $INPUT_OPTIONS "--entrypoint=$INPUT_SHELL" "$INPUT_IMAGE" -c "${INPUT_RUN//$'\n'/;}"


### PR DESCRIPTION
Update  `entrypoint.sh` to quote various inputs so that they don't cause unexpected argument splitting, which may result in unexpected behavior or even completely changing the behavior of commands.

This covers all inputs expect the options, which (unfortunately) intentionally relies on argument splitting.