### PR TITLE
Update base image to docker:29.2.1 to fix API compatibility with modern runners

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-FROM docker:20.10
+FROM docker:29.2.1
 
 RUN apk add bash
-
-COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,5 @@ FROM docker:29.2.1
 
 RUN apk add bash
 
+COPY entrypoint.sh /entrypoint.sh 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Docker engine 20.10 is no longer compatible with the ubuntu-latest github hosted runners