### PR TITLE
Make the docker image reproducible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM docker:20.10
 
-RUN apk add bash
+RUN apk add --no-cache bash && \
+    rm -rf /lib/apk/db/*
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Update usage of `apk` so that building twice in a row results in identical images.